### PR TITLE
Don't require garden.core early.

### DIFF
--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -9,7 +9,6 @@
    [leiningen.help :as help]
    [leiningen.compile :as lcompile]
    [robert.hooke :as hooke]
-   [garden.core]
    [me.raynes.fs :as fs]))
 
 (defn- builds [project]


### PR DESCRIPTION
Fixes #22.

I'm still not sure _why_ `record?` isn't available for me that early, but regardless, this require isn't necessary. `lein-garden` doesn't actually use `garden.core` on the Leiningen side. Only the project code needs to require it, which it does in the `eval-in-project` form later on.
