### PR TITLE
Concat build source-paths with project source-paths

### DIFF
--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -88,8 +88,8 @@
   (let [builds (if (seq args)
                  (find-builds project args)
                  (builds project))
-        paths (vec (distinct (flatten (map #(% :source-paths) builds))))
-        modified-project (update-in project [:source-paths] (fn [src-path] paths))
+        build-paths (mapcat :source-paths builds)
+        modified-project (update-in project [:source-paths] concat build-paths)
         requires (load-namespaces (map :stylesheet builds))]
     (when (seq builds)
       (doseq [build builds] (prepare-build build))


### PR DESCRIPTION
Just ran in to a bug pertaining to this recent change: https://github.com/noprompt/lein-garden/pull/21/files#diff-dd137de1c12ebb1560fec2bfc1052f09R97. If you rely on any dependencies, they no longer get included in the class-path. Leiningen expands `:source-paths` to include your dependency paths, which it needs to add them to the class path.

It looks like lein-cljsbuild concats in the source-paths specified in each build with the original project's source-paths: https://github.com/emezeske/lein-cljsbuild/blob/master/plugin/src/leiningen/cljsbuild/subproject.clj#L102-L105.

This PR just concats the build source-paths with the original project source-paths so you don't lose dependency paths.
