### PR TITLE
Removed hooks and fixed endless compilation problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Leiningen plugin for automatically compiling
 ## Requirements
 
 This plugin requires Clojure version `1.6.0` or higher and Leiningen
-version `2.4.3` or higher.
+version `2.5.0` or higher.
 
 ## Installation
 
@@ -106,18 +106,8 @@ and behold as your stylesheet is automatically recompiled on save.
 Now you might want stylesheets to always compile whenever starting your program with leiningen.
 Add this to your `project.clj`
 
-```:hooks [leiningen.garden]```
-
-You might not want your stylesheets to compile before test-runs.
-Perhaps what you really wanted, is to compile stylesheets before creating a jar.
-You can use profiles to do this.
-
-```:profiles {:uberjar {:hooks [leiningen.garden]}}```
+```:prep-tasks [["garden" "once"]]```
 
 ### Chapter 4
 
-Finally, to remove any compiled stylesheets, simply run
-
-```shell
-$ lein garden clean
-```
+To remove css on `lein clean`, you should add the compiled files to `:clean-targets` in your `project.clj`

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :url "https://github.com/noprompt/lein-garden"
   :license {:name "Unlicense"
             :url "http://unlicense.org/UNLICENSE"}
+  :min-lein-version "2.5.0"
   :eval-in-leiningen true
   :dependencies [[garden "1.2.1"]
                  [me.raynes/fs "1.4.4"]

--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -89,7 +89,12 @@
                  (find-builds project args)
                  (builds project))
         build-paths (mapcat :source-paths builds)
-        modified-project (update-in project [:source-paths] concat build-paths)
+        modified-project (-> project
+                             (select-keys [:dependencies
+                                           :plugin
+                                           :source-paths
+                                           :garden])
+                             (update-in [:source-paths] concat build-paths))
         requires (load-namespaces (map :stylesheet builds))]
     (when (seq builds)
       (doseq [build builds] (prepare-build build))

--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -7,9 +7,6 @@
    [leiningen.core.eval :refer [eval-in-project]]
    [leiningen.core.project :refer [merge-profiles]]
    [leiningen.help :as help]
-   [leiningen.compile :as lcompile]
-   [leiningen.clean :as lclean]
-   [robert.hooke :as hooke]
    [me.raynes.fs :as fs]))
 
 (defn- builds [project]
@@ -116,19 +113,6 @@
   [project args]
   (run-compiler project args true))
 
-(defn- clean
-  "Removes compiled Garden stylesheets"
-  [project args]
-  (let [builds (if (seq args)
-                 (find-builds project args)
-                 (builds project))
-        paths (distinct (map #(get-in % [:compiler :output-to]) builds))]
-    (println "Cleaning Garden...")
-    (doseq [file paths]
-      (println "Removing file:" file)
-      (io/delete-file file true))))
-
-
 
 (def ^:private garden-profile
   {:dependencies '[^:displace [garden "1.2.1"]
@@ -136,8 +120,8 @@
 
 (defn garden
   "Compile Garden stylesheets."
-  {:help-arglists '([once auto clean])
-   :subtasks [#'once #'auto #'clean]}
+  {:help-arglists '([once auto])
+   :subtasks [#'once #'auto]}
   [project & args]
   (let [project (merge-profiles project [garden-profile])
         [command & args] args]
@@ -145,34 +129,8 @@
     (case command
       "once" (once project args)
       "auto" (auto project args)
-      "clean" (clean project args)
       (do
         (println
          (when command (str "Unknown command:" command))
          (help/subtask-help-for *ns* #'garden))
         (main/abort)))))
-
-
-;; Compile hook is executed multiple times for some reason
-;; Found this workaround in cljx
-(def ^:private compiled? (atom false))
-
-(defn- compile-hook [task & args]
-  (when-not @compiled?
-    (reset! compiled? true)
-    (let [project (merge-profiles (first args) [garden-profile])]
-      (validate-builds project)
-      (once project (next args))))
-  (apply task args))
-
-(defn- clean-hook [task & args]
-  (let [project (merge-profiles (first args) [garden-profile])]
-    (validate-builds project)
-    (clean project (next args)))
-  (apply task args))
-
-(defn activate
-  "Setup hooks for the plugin"
-  []
-  (hooke/add-hook #'lcompile/compile #'compile-hook)
-  (hooke/add-hook #'lclean/clean #'clean-hook))


### PR DESCRIPTION
Today in leiningen, you can use :prep-tasks instead of hooks. You can also use :clean-targets instead of a hook to clean compiled files on lein clean. For this reason cljsbuild has dropped support for hooks, we should do the same.

When removing this, I came upon a serious problem where compilation would go on in an endless loop. I fixed this as well.

Should probably cut a release after this :)