### PR TITLE
Fixes #31 (prevent source-path merging).

### DIFF
--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -89,7 +89,6 @@
         modified-project (-> project
                              (select-keys [:dependencies
                                            :plugin
-                                           :source-paths
                                            :garden])
                              (update-in [:source-paths] concat build-paths))
         requires (load-namespaces (map :stylesheet builds))]


### PR DESCRIPTION
This patch prevents the garden task from merging the top-level
:source-path key in a project.clj with the :source-path key in the
:garden definitions. This prevents changes in the main Clojure source
tree (unrelated to CSS) from causing the CSS to be regenerated.