### PR TITLE
Fix issue of "No such var: fs/absolute-path"

### DIFF
--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -43,7 +43,7 @@
 (defn- ensure-output-directory-exists [build]
   (let [dir (-> (output-path build)
                 io/file
-                fs/absolute-path
+                fs/absolute
                 fs/parent)]
     (when-not (fs/exists? dir)
       (when-not (fs/mkdirs dir)


### PR DESCRIPTION
The function `fs/absolute-path` was renamed to `fs/absolute` in [me.raynes/fs](https://github.com/Raynes/fs/blob/a4e131b5a50e63a447476940541cc5a88376857a/src/me/raynes/fs.clj#L76).