### PR TITLE
Fix no such var fs/absolute

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,5 +6,5 @@
   :min-lein-version "2.5.0"
   :eval-in-leiningen true
   :dependencies [[garden "1.3.1"]
-                 [me.raynes/fs "1.4.4"]
+                 [me.raynes/fs "1.4.6"]
                  [ns-tracker "0.3.0"]])


### PR DESCRIPTION
Seems this has come up before.  `fs` version 1.4.4 (upon which this project depends) has the function `absolute-path` but we use `absolute` (fixing previous tickets.)  I'm not sure how this was working - maybe the submitter of the PR was actually solving a local dependency conflict i.e. they were depending on 1.4.6, usurping the 1.4.4 here?  In any case to use `fs/absolute` this project needs to update it's dependency on `fs` to 1.4.6, as per this change.