### PR TITLE
Use project repositories for eval-in-project

### DIFF
--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -90,7 +90,8 @@
                              (select-keys [:dependencies
                                            :plugin
                                            :local-repo
-                                           :garden])
+                                           :garden
+                                           :repositories])
                              (update-in [:source-paths] concat build-paths))
         requires (load-namespaces (map :stylesheet builds))]
     (when (seq builds)


### PR DESCRIPTION
Else repositories from pom.xml's of deps need to be used and those are
currently not written by Boot.

https://github.com/cljsjs/packages/issues/686
https://github.com/boot-clj/boot/issues/496
