### PR TITLE
honor local-repo setting in builds

### DIFF
--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -89,6 +89,7 @@
         modified-project (-> project
                              (select-keys [:dependencies
                                            :plugin
+                                           :local-repo
                                            :garden])
                              (update-in [:source-paths] concat build-paths))
         requires (load-namespaces (map :stylesheet builds))]


### PR DESCRIPTION
Otherwise dependencies will not be found if not present in user repo.