### PR TITLE
Fix on assumptive call to clojure.core/name

### DIFF
--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -25,14 +25,16 @@
 (defn- validate-builds [project]
   (doseq [{:keys [id stylesheet source-paths] :as build} (builds project)]
     (cond
-     (nil? source-paths)
-     (throw (Exception. (format "No source-paths specified in build %s. " (name id))))
-     (nil? stylesheet)
-     (throw (Exception. (format "No stylesheet specified in build %s. " (name id))))
-     (not (symbol? stylesheet))
-     (throw (Exception. (format ":stylesheet value must be a symbol in build %s." (name id))))
-     (nil? (output-path build))
-     (throw (Exception. (format "No :output-to file specified in build %s." (name id)))))))
+      (nil? id)
+      (throw (Exception. "Build must have an id"))
+      (nil? source-paths)
+      (throw (Exception. (format "No source-paths specified in build %s. " (name id))))
+      (nil? stylesheet)
+      (throw (Exception. (format "No stylesheet specified in build %s. " (name id))))
+      (not (symbol? stylesheet))
+      (throw (Exception. (format ":stylesheet value must be a symbol in build %s." (name id))))
+      (nil? (output-path build))
+      (throw (Exception. (format "No :output-to file specified in build %s." (name id)))))))
 
 ;; I'm unsure if this is actually necessary.
 (defn- load-namespaces [syms]

--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -25,8 +25,8 @@
 (defn- validate-builds [project]
   (doseq [{:keys [id stylesheet source-paths] :as build} (builds project)]
     (cond
-      (nil? id)
-      (throw (Exception. "Build must have an id"))
+      (not (string? id))
+      (throw (Exception. "Build's id must be a string"))
       (nil? source-paths)
       (throw (Exception. (format "No source-paths specified in build %s. " (name id))))
       (nil? stylesheet)


### PR DESCRIPTION
Fix to issue #39. The early validation of id ensures call to name don't need to worry about it being null