### PR TITLE
Acknowledge private repositories

### DIFF
--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -91,7 +91,8 @@
                                            :plugin
                                            :local-repo
                                            :garden
-                                           :repositories])
+                                           :repositories
+                                           :mirrors])
                              (update-in [:source-paths] concat build-paths))
         requires (load-namespaces (map :stylesheet builds))]
     (when (seq builds)

--- a/src/leiningen/garden.clj
+++ b/src/leiningen/garden.clj
@@ -87,12 +87,6 @@
                  (builds project))
         build-paths (mapcat :source-paths builds)
         modified-project (-> project
-                             (select-keys [:dependencies
-                                           :plugin
-                                           :local-repo
-                                           :garden
-                                           :repositories
-                                           :mirrors])
                              (update-in [:source-paths] concat build-paths))
         requires (load-namespaces (map :stylesheet builds))]
     (when (seq builds)


### PR DESCRIPTION
This patch fixes the issue with the ignored :mirrors key in project.clj (https://github.com/noprompt/lein-garden/issues/51).